### PR TITLE
fix: fix configs to re-enable eslint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-	"extends": ["next/core-web-vitals", "prettier"]
-}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,20 @@
+import { defineConfig, globalIgnores } from "eslint/config";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import js from "@eslint/js";
+import { FlatCompat } from "@eslint/eslintrc";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const compat = new FlatCompat({
+	baseDirectory: __dirname,
+	recommendedConfig: js.configs.recommended,
+	allConfig: js.configs.all,
+});
+
+export default defineConfig([
+	{
+		extends: compat.extends("next/core-web-vitals", "prettier"),
+	},
+	globalIgnores(["**/.next/**"]),
+]);

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,5 +1,8 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+	eslint: {
+		ignoreDuringBuilds: true,
+	},
 	images: {
 		remotePatterns: [
 			{

--- a/package.json
+++ b/package.json
@@ -7,9 +7,10 @@
     "test": "vitest",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint",
+    "lint": "eslint .",
     "format:check": "prettier --check ./src",
-    "format:write": "prettier ./src --write"
+    "format:write": "prettier ./src --write",
+    "prebuild": "pnpm run lint"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.0.0",
@@ -66,6 +67,9 @@
     "zod": "^3.25.7"
   },
   "devDependencies": {
+    "@eslint/eslintrc": "^3.3.1",
+    "@eslint/js": "^9.29.0",
+    "@next/eslint-plugin-next": "^15.3.4",
     "@tanstack/eslint-plugin-query": "^5.60.1",
     "@testing-library/react": "^16.3.0",
     "@types/d3": "^7.4.3",
@@ -77,6 +81,7 @@
     "eslint": "^9.0.0",
     "eslint-config-next": "15.3.4",
     "eslint-config-prettier": "^10.0.0",
+    "eslint-plugin-react-hooks": "^5.2.0",
     "jsdom": "^26.1.0",
     "postcss": "^8.4.49",
     "prettier": "^3.5.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,6 +165,15 @@ importers:
         specifier: ^3.25.7
         version: 3.25.67
     devDependencies:
+      '@eslint/eslintrc':
+        specifier: ^3.3.1
+        version: 3.3.1
+      '@eslint/js':
+        specifier: ^9.29.0
+        version: 9.29.0
+      '@next/eslint-plugin-next':
+        specifier: ^15.3.4
+        version: 15.3.4
       '@tanstack/eslint-plugin-query':
         specifier: ^5.60.1
         version: 5.78.0(eslint@9.29.0(jiti@1.21.7))(typescript@5.8.3)
@@ -198,6 +207,9 @@ importers:
       eslint-config-prettier:
         specifier: ^10.0.0
         version: 10.1.5(eslint@9.29.0(jiti@1.21.7))
+      eslint-plugin-react-hooks:
+        specifier: ^5.2.0
+        version: 5.2.0(eslint@9.29.0(jiti@1.21.7))
       jsdom:
         specifier: ^26.1.0
         version: 26.1.0


### PR DESCRIPTION
Upgrading to eslint v9 broke the linting. The changes here fixes and reenabled the linter.