### PR TITLE
feat: add api route to grab images dynamically

### DIFF
--- a/src/app/api/cron/route.ts
+++ b/src/app/api/cron/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from "next/server";
+
+export async function GET() {
+	return NextResponse.json({ ok: true });
+}

--- a/src/app/api/notion-images/route.ts
+++ b/src/app/api/notion-images/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export async function GET(req: NextRequest) {
+	const url = req.nextUrl.searchParams.get("url");
+	if (!url) {
+		return new NextResponse("Missing url", { status: 400 });
+	}
+
+	// Only allow Notion S3 URLs for security
+	if (
+		!url.startsWith("https://prod-files-secure.s3.") &&
+		!url.startsWith(
+			"https://s3.us-west-2.amazonaws.com/secure.notion-static.com/"
+		)
+	) {
+		return new NextResponse("Invalid Notion image URL", { status: 400 });
+	}
+
+	const notionRes = await fetch(url);
+
+	const contentType = notionRes.headers.get("content-type") || "";
+	if (!contentType.startsWith("image/")) {
+		const text = await notionRes.text();
+		return new NextResponse(
+			`The requested resource isn't a valid image: ${text}`,
+			{ status: 400 }
+		);
+	}
+
+	const imageBuffer = await notionRes.arrayBuffer();
+	return new NextResponse(Buffer.from(imageBuffer), {
+		status: 200,
+		headers: {
+			"Content-Type": contentType,
+			"Cache-Control": "public, max-age=86400",
+		},
+	});
+}

--- a/src/lib/searchUtils.ts
+++ b/src/lib/searchUtils.ts
@@ -84,7 +84,7 @@ export function createSearchIndex(pages: PageObjectResponse[]): SearchIndex {
 						.join("") || ""
 				: "";
 
-		const imageUrl =
+		const imageUrlPreProxy =
 			page.properties.card_image.type === "files"
 				? page.properties.card_image.files[0]?.type === "file"
 					? page.properties.card_image.files[0].file.url
@@ -92,6 +92,10 @@ export function createSearchIndex(pages: PageObjectResponse[]): SearchIndex {
 						? page.properties.card_image.files[0].external.url
 						: ""
 				: "";
+
+		const imageUrl = imageUrlPreProxy
+			? `/api/notion-images?url=${encodeURIComponent(imageUrlPreProxy)}`
+			: undefined;
 
 		const imageCredit =
 			page.properties.card_image_credit.type === "rich_text"

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+	"crons": [
+		{
+			"path": "/api/cron",
+			"schedule": "0 1 * * *"
+		}
+	]
+}


### PR DESCRIPTION
- Includes setting up of scheduled re-deployments on Vercel

This is to ensure that images from notion don't expire and new ones are fetched as/when needed